### PR TITLE
libtiff-4.pc: Fix `Requires.private` missing `Lerc`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -735,6 +735,7 @@ if test "$HAVE_LERC" = "yes" ; then
   AC_DEFINE(LERC_SUPPORT,1,[Support lerc compression])
   LIBS="-l${lerc_lib_name} $LIBS"
   tiff_libs_private="-l${lerc_lib_name} ${tiff_libs_private}"
+  tiff_requires_private="Lerc ${tiff_requires_private}"
 
   if test "$HAVE_RPATH" = "yes" -a "x$with_lerc_lib_dir" != "x" ; then
     LIBDIR="-R $with_lerc_lib_dir $LIBDIR"


### PR DESCRIPTION
It provides a `.pc` file starting from version 4 in:

https://github.com/Esri/lerc/blob/8d6e8251544bbe1379feb0fe0a0934e43ca1a6cd/Lerc.pc.in

libtiff's CMake build system already has support for this, adding `Lerc` to `Requires.private` if Lerc is >= 4 (see https://github.com/libsdl-org/libtiff/commit/995763a316522e8d211290dfb7068b6c188c5dd7).

In contrast to the CMake build system, autoconf has no good way to check for checking the Lerc version, we do it unconditionally there.