### PR TITLE
Enable support for arm64EC

### DIFF
--- a/libtiff/tif_predict.c
+++ b/libtiff/tif_predict.c
@@ -30,7 +30,7 @@
 #include "tif_predict.h"
 #include "tiffiop.h"
 
-#if defined(__x86_64__) || defined(_M_X64)
+#if defined(__x86_64__) || (defined(_M_X64) && !defined(_M_ARM64EC))
 #include <emmintrin.h>
 #endif
 
@@ -594,7 +594,7 @@ static int fpAcc(TIFF *tif, uint8_t *cp0, tmsize_t cc)
     cp = (uint8_t *)cp0;
     count = 0;
 
-#if defined(__x86_64__) || defined(_M_X64)
+#if defined(__x86_64__) || (defined(_M_X64) && !defined(_M_ARM64EC))
     if (bps == 4)
     {
         /* Optimization of general case */


### PR DESCRIPTION
[+] Avoided including "SSE2 intrinsics" when building for arm64EC.
